### PR TITLE
fix(wordpress): accept empty object for topologySpreadConstraints

### DIFF
--- a/charts/wordpress/values.schema.json
+++ b/charts/wordpress/values.schema.json
@@ -1740,11 +1740,14 @@
       "default": {}
     },
     "topologySpreadConstraints": {
-      "type": "array",
+      "type": [
+        "array",
+        "object"
+      ],
       "items": {
         "type": "object"
       },
-      "description": "Topology spread constraints for pods",
+      "description": "Topology spread constraints for pods (accepts an empty object for backwards compatibility with pre-4.x values)",
       "default": []
     },
     "priorityClassName": {
@@ -2784,8 +2787,11 @@
           }
         },
         "topologySpreadConstraints": {
-          "type": "array",
-          "description": "Topology spread constraints for Redis pods",
+          "type": [
+            "array",
+            "object"
+          ],
+          "description": "Topology spread constraints for Redis pods (accepts an empty object for backwards compatibility)",
           "default": []
         },
         "containerSecurityContext": {


### PR DESCRIPTION
## Problem

Upgrading the WordPress chart from **3.3.x** to a current version fails schema validation (reported in #506):

```
Error: UPGRADE FAILED: values don't meet the specifications of the schema(s):
wordpress:
- at '/topologySpreadConstraints': got object, want array
```

Charts `<= 3.3.x` defaulted `topologySpreadConstraints` to an empty object `{}`. Users who carried that value into their own `values.yaml` now hit `type: array` validation on `helm upgrade`.

## Fix

Relax `values.schema.json` (top-level and the redis subsection) so `topologySpreadConstraints` accepts both `array` and `object`. The pod template already skips an empty `{}` via `{{- with … }}`, and a populated array renders unchanged — this is a purely backwards-compatible schema change. No `values.yaml` defaults were touched.

## Verification

- `helm template` with `topologySpreadConstraints: {}` now renders successfully (the exact #506 failure is gone) and emits no `topologySpreadConstraints` field.
- `helm template` with the array value (`samples/ha-statefulset.values.yaml`) renders unchanged.
- `verify.sh` run against a live cluster: green.

Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)