### PR TITLE
fix(ci): stop assigning auto-mergeable Renovate/release PRs

### DIFF
--- a/.github/workflows/oci-release.yaml
+++ b/.github/workflows/oci-release.yaml
@@ -56,6 +56,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      pull-requests: write
     steps:
       - name: Resolve release context
         id: ctx
@@ -440,3 +441,27 @@ jobs:
 
           oras manifest fetch "ghcr.io/slybase/charts/$CHART_NAME:artifacthub.io" > "$tmp_manifest"
           jq -e '.config.size > 0 and .config.mediaType == "application/vnd.cncf.artifacthub.config.v1+yaml" and (.layers | length) == 1' "$tmp_manifest"
+
+      # Only source of "a release actually shipped" notification: pr-auto-assign.yml
+      # deliberately does not assign release-please PRs, so without this nobody
+      # would hear about a completed release bump.
+      - name: Notify merged release PR
+        if: steps.ctx.outputs.dry_run != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHART_NAME: ${{ steps.chart.outputs.chart_name }}
+          CHART_VERSION: ${{ steps.chart.outputs.chart_version }}
+        run: |
+          set -euo pipefail
+
+          branch="release-please--branches--main--components--${CHART_NAME}"
+          pr=$(gh pr list --state merged --search "head:${branch}" \
+                 --json number,mergedAt --limit 1 --jq 'sort_by(.mergedAt) | reverse | .[0].number // empty')
+
+          if [ -z "$pr" ]; then
+            echo "::warning::could not find merged release PR for $branch; skipping notify"
+            exit 0
+          fi
+
+          gh pr comment "$pr" --body "🚀 @slydlake Released **${CHART_NAME} v${CHART_VERSION}** to \`ghcr.io/slybase/charts\`."

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -1,5 +1,12 @@
 name: PR Auto Assign
 
+# Assigns slydlake on newly opened issues/PRs, EXCEPT PRs that need no manual
+# action: release-please release PRs and Renovate PRs slated for automerge.
+# Those either merge themselves or are handled by dedicated notify steps
+# (release-please-automerge.yml assigns on major/prerelease; a failed
+# automerge run assigns via renovate-automerge-failure-notify.yml) — assigning
+# them here too would just be extra push notifications for nothing to do.
+
 "on":
   pull_request_target:
     types: [opened]
@@ -17,6 +24,23 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
+            const pr = context.payload.pull_request;
+            if (pr) {
+              const labels = (pr.labels || []).map((l) => l.name);
+              const isReleasePlease = pr.head.ref.startsWith(
+                'release-please--branches--main--components--'
+              );
+              const isAutomergingRenovate =
+                labels.includes('renovate') && labels.includes('automerge');
+              if (isReleasePlease || isAutomergingRenovate) {
+                console.log(
+                  `Skipping assignment: ${
+                    isReleasePlease ? 'release-please PR' : 'auto-merging Renovate PR'
+                  } needs no manual action`
+                );
+                return;
+              }
+            }
             await github.rest.issues.addAssignees({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/release-please-automerge.yml
+++ b/.github/workflows/release-please-automerge.yml
@@ -41,7 +41,7 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   automerge:
@@ -79,6 +79,9 @@ jobs:
         run: |
           set -euo pipefail
           skip() { echo "decision: SKIP — $1"; echo "merge=false" >> "$GITHUB_OUTPUT"; exit 0; }
+          # Only major bumps and prereleases stay open for a human to merge by hand;
+          # assign so that (unlike routine patch/minor automerges) this one notifies.
+          assign_for_manual_review() { gh pr edit "$PR" --add-assignee slydlake >/dev/null 2>&1 || true; }
 
           meta=$(gh pr view "$PR" --json state,headRefName,isCrossRepository,title)
           state=$(jq -r .state <<<"$meta")
@@ -104,10 +107,11 @@ jobs:
 
           { [ -n "$old" ] && [ -n "$new" ]; } || skip "could not read versions"
           [ "$old" != "$new" ] || skip "no version change"
-          case "$new" in *-*) skip "prerelease $new" ;; esac
+          case "$new" in *-*) assign_for_manual_review; skip "prerelease $new" ;; esac
 
           # Patch + Minor auto-merge; a MAJOR bump stays manual.
           if [ "${new%%.*}" != "${old%%.*}" ]; then
+            assign_for_manual_review
             skip "major bump $old -> $new (manual review)"
           fi
 

--- a/.github/workflows/renovate-automerge-failure-notify.yml
+++ b/.github/workflows/renovate-automerge-failure-notify.yml
@@ -1,0 +1,45 @@
+name: Renovate Automerge Failure Notify
+
+# Renovate PRs labeled "automerge" rely on GitHub-native platformAutomerge:
+# they merge themselves once CI is green, so pr-auto-assign.yml deliberately
+# skips assigning them (see that file). But if CI fails, native automerge
+# never fires and the PR just sits open with nobody assigned — nothing would
+# tell us. This watches the two PR-validation workflows and assigns slydlake
+# only when an automerge-labeled PR's checks actually failed.
+
+on:
+  workflow_run:
+    workflows: ["PR Chart Validate", "Chart Install Test"]
+    types: [completed]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  notify:
+    if: github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign on automerge failure
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const prRefs = context.payload.workflow_run.pull_requests || [];
+            for (const prRef of prRefs) {
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prRef.number
+              });
+              if (pr.state !== 'open') continue;
+              const labels = (pr.labels || []).map((l) => l.name);
+              if (!labels.includes('automerge')) continue;
+              console.log(`PR #${pr.number}: automerge checks failed, assigning slydlake`);
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                assignees: ['slydlake']
+              });
+            }


### PR DESCRIPTION
## Summary
- `pr-auto-assign.yml` no longer assigns release-please PRs or Renovate PRs labeled `automerge` — those merge themselves and don't need manual action, so assigning them was just extra push notifications.
- `release-please-automerge.yml` now assigns the release PR when its gate decides a major bump or prerelease needs manual merging.
- New `renovate-automerge-failure-notify.yml` assigns an `automerge`-labeled PR if its checks (`PR Chart Validate` / `Chart Install Test`) actually fail, since GitHub-native automerge would otherwise leave it silently open.
- `oci-release.yaml` posts an `@slydlake`-mention comment on the merged release PR once a chart is actually published, so a shipped release still gets a notification.

## Test plan
- [x] `yamllint` / pre-commit hooks pass
- [x] All four workflow files validated as parseable YAML
- [ ] Observe next Renovate run: automerge-eligible PRs open without assignee
- [ ] Observe next release-please tag: merged release PR gets an @-mention comment