### PR TITLE
chore(renovate): add appVersion tracking marker for wordpress and wg-easy

### DIFF
--- a/charts/wg-easy/Chart.yaml
+++ b/charts/wg-easy/Chart.yaml
@@ -5,7 +5,7 @@ description: >-
   for K8s. Supporting Init Mode.
 type: application
 version: 1.1.0
-appVersion: 15.3.0
+appVersion: 15.3.0 # renovate: image=ghcr.io/wg-easy/wg-easy
 icon: >-
   https://raw.githubusercontent.com/slydlake/helm-charts/refs/heads/main/charts/wg-easy/app.png
 home: https://github.com/slydlake/helm-charts

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -5,7 +5,7 @@ description: >-
   installation, user management, plugin installation, and metrics.
 type: application
 version: 5.1.26
-appVersion: 7.0.0
+appVersion: 7.0.0 # renovate: image=docker.io/wordpress
 icon: >-
   https://raw.githubusercontent.com/slydlake/helm-charts/refs/heads/main/charts/wordpress/app.png
 home: https://github.com/slydlake/helm-charts


### PR DESCRIPTION
## Summary
- The generic appVersion `customManager` in `renovate.json` only updates `appVersion` in a chart's `Chart.yaml` when the line carries a trailing `# renovate: image=<packageName>` marker comment.
- `wordpress` and `wg-easy` never had this marker, so Renovate kept bumping `values.yaml` and the `artifacthub.io/images` annotation, but `appVersion` silently stayed behind (e.g. wordpress `appVersion: 7.0.0` while the image annotation showed `7.0.1`).
- `wireguard` already has its own dedicated custom manager and is unaffected.
- Values are left unchanged on purpose (wordpress stays at `7.0.0`) so the next Renovate run can be observed bumping it automatically.

## Test plan
- [x] `helm lint` / yamllint / ArtifactHub annotation validation passed via pre-commit hooks
- [ ] Watch next Renovate run: confirm it opens a PR bumping `wordpress` appVersion to `7.0.1` and `wg-easy` appVersion stays tracked