### PR TITLE
fix(renovate): stop wireguard patch updates being filtered as unstable

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -95,7 +95,8 @@
             "matchPackageNames": [
                 "docker.io/linuxserver/wireguard"
             ],
-            "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-r(?<prerelease>\\d+)-ls(?<build>\\d+)$"
+            "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-r(?<prerelease>\\d+)-ls(?<build>\\d+)$",
+            "ignoreUnstable": false
         },
         {
             "description": "Group direct dependency updates per chart and target version",


### PR DESCRIPTION
## Summary
- linuxserver/wireguard's custom regex versioning names its `-rN-` segment as the `prerelease` group, which makes Renovate's generic versioning treat every tag (including the currently installed one) as unstable
- The default `ignoreUnstable: true` filter only allows unstable→unstable upgrades when major/minor/patch stay identical, but the date-like patch component (`20250521` → `20260223`) changes on every release, so no update was ever proposed even though newer tags exist upstream (e.g. `1.0.20260223-r0-ls118`)
- Adds `"ignoreUnstable": false` to the wireguard-specific packageRule to bypass this filter for this one dependency

## Root cause verification
Reproduced directly against Renovate's `lookupUpdates()`:
- with `ignoreUnstable: true` → `updates: []` (bug reproduced)
- with `ignoreUnstable: false` → `updates: [{ newVersion: "1.0.20260223-r0-ls118", updateType: "patch", ... }]` (fix confirmed)

wg-easy was checked too and does **not** have this problem — it uses plain docker/semver versioning without a custom prerelease-like group, and `15.3.0` is genuinely the latest upstream release.

## Test plan
- [x] `renovate-config-validator renovate.json` passes
- [x] Isolated `lookupUpdates()` reproduction confirms the fix restores the missing update
- [ ] Next scheduled Renovate run (or manual `workflow_dispatch`) should open a PR bumping wireguard to `1.0.20260223-r0-ls118`

🤖 Generated with [Claude Code](https://claude.com/claude-code)