### PR TITLE
feat(wordpress): bootstrap native redis PHP extension for redis/valkey backend

### DIFF
--- a/charts/wordpress/samples/verify/verify.sh
+++ b/charts/wordpress/samples/verify/verify.sh
@@ -204,9 +204,39 @@ else
   yellow "  [SKIP] No wordpress pod — cannot check OPcache"
 fi
 
-# ── 15. WordPress auth keys/salts pinned ──────────────────────────────────────
+# ── 15. Native redis extension loaded (values.yaml enables valkey backend) ───
 bold ""
-bold "==> Step 15: WordPress auth keys/salts pinned (statefulset / wp-content layouts)"
+bold "==> Step 15: Native redis PHP extension loaded (valkey backend enabled)"
+if [[ -n "${WP_POD}" ]]; then
+  # pipe-free check (avoids SIGPIPE aborting the script under set -o pipefail, same as check_logs())
+  if kubectl exec "${WP_POD}" -c wordpress -- \
+      php -r 'exit(in_array("redis", get_loaded_extensions(), true) ? 0 : 1);' 2>/dev/null; then
+    green "  [OK] Native redis extension loaded"
+  else
+    red "  [FAIL] Native redis extension not loaded (expected with valkey.enabled=true)"
+    ERRORS=$((ERRORS + 1))
+  fi
+else
+  yellow "  [SKIP] No wordpress pod — cannot check redis extension"
+fi
+
+# ── 16. object-cache.php drop-in present ──────────────────────────────────────
+bold ""
+bold "==> Step 16: object-cache.php drop-in present"
+if [[ -n "${WP_POD}" ]]; then
+  if kubectl exec "${WP_POD}" -c wordpress -- test -f /var/www/html/wp-content/object-cache.php 2>/dev/null; then
+    green "  [OK] object-cache.php drop-in present"
+  else
+    red "  [FAIL] object-cache.php drop-in not found (expected with valkey.enabled=true + redis-cache plugin active)"
+    ERRORS=$((ERRORS + 1))
+  fi
+else
+  yellow "  [SKIP] No wordpress pod — cannot check object-cache.php"
+fi
+
+# ── 17. WordPress auth keys/salts pinned ──────────────────────────────────────
+bold ""
+bold "==> Step 17: WordPress auth keys/salts pinned (statefulset / wp-content layouts)"
 SALT_COUNT=$(kubectl get secret "${RELEASE}" \
   -o go-template='{{range $k,$v := .data}}{{$k}}{{"\n"}}{{end}}' 2>/dev/null \
   | grep -cE '^WORDPRESS_(AUTH|SECURE_AUTH|LOGGED_IN|NONCE)_(KEY|SALT)$' || true)

--- a/charts/wordpress/templates/_init-script.tpl
+++ b/charts/wordpress/templates/_init-script.tpl
@@ -144,16 +144,20 @@ fi
 export TABLE_PREFIX
 echo "Using WordPress table prefix: ${TABLE_PREFIX}"
 
-{{- if .Values.memcached.enabled }}
-# wp-cli in wordpress-init container runs without memcached extension.
-# If a stale object-cache.php exists on PVC, wp bootstrap can fatally fail.
+# wp-cli in wordpress-init container always runs without the native memcached
+# extension (the memcached-bootstrap initContainer that provides it runs later,
+# after wordpress-init). If a stale memcached-plugin object-cache.php is present
+# on the PVC - whether memcached is currently enabled or was left over from a
+# previous release that had it enabled - wp-cli bootstrap fatally errors on
+# every call, including plain `wp core install`/`wp core is-installed`. So this
+# guard is unconditional, not gated on memcached.enabled. redis-cache's drop-in
+# doesn't need it: it falls back to Predis gracefully without the extension.
 MEMCACHED_DROPIN="/var/www/html/wp-content/object-cache.php"
 MEMCACHED_DROPIN_DISABLED="/var/www/html/wp-content/object-cache.php.helm-disabled"
 if [ -f "$MEMCACHED_DROPIN" ] && ! php -m | grep -qi '^memcached$'; then
   echo "Temporarily disabling existing object-cache.php for wp-cli init..."
   mv "$MEMCACHED_DROPIN" "$MEMCACHED_DROPIN_DISABLED" || true
 fi
-{{- end }}
 
 # ============================================================================
 # Bootstrap Lock Acquisition (Before WordPress Installation)
@@ -1531,9 +1535,11 @@ if [ "$PLUGINS_MODIFIED" = "true" ] || [ "$COMPOSER_PACKAGES_MODIFIED" = "true" 
   ACTIVE_PLUGINS=$(wp_plugin_list --status=active --field=name 2>/dev/null || echo "")
 fi
 
+{{- $cacheBackends := (include "wordpress.cache.backends" . | fromYaml) }}
 # ============================================================================
 # Redis/Valkey Object Cache Enable (redis-cache plugin)
 # ============================================================================
+{{- if or (eq $cacheBackends.selected "redis") (eq $cacheBackends.selected "valkey") }}
 # Applies to both Redis and Valkey backends via the same redis-cache plugin.
 if wp plugin is-active redis-cache 2>/dev/null; then
   echo "Ensuring redis-cache object cache is enabled (Redis/Valkey)..."
@@ -1551,15 +1557,52 @@ if wp plugin is-active redis-cache 2>/dev/null; then
   echo "redis-cache status after:"
   (wp_with_plugins redis status 2>&1 | grep -E "Status:|Client:|Drop-in:" || wp_with_plugins redis status 2>&1 || true)
 fi
+{{- else }}
+# No Redis/Valkey backend selected - clean up any stale redis-cache plugin/drop-in state
+# left over from a previous release where a backend was enabled.
+REDIS_DROPIN_TARGET="/var/www/html/wp-content/object-cache.php"
+REDIS_PLUGIN_DROPIN="/var/www/html/wp-content/plugins/redis-cache/includes/object-cache.php"
+REDIS_DROPIN_DISABLED_BACKEND="/var/www/html/wp-content/object-cache.php.helm-disabled-backend"
 
-{{- if .Values.memcached.enabled }}
+if wp plugin is-active redis-cache 2>/dev/null; then
+  echo "Redis/Valkey backend disabled; deactivating redis-cache plugin..."
+  wp plugin deactivate redis-cache 2>/dev/null || true
+fi
+
+# The early wp-cli guard above unconditionally moves any existing object-cache.php
+# to $MEMCACHED_DROPIN_DISABLED before running (since the init container never has
+# the memcached extension) - so the current drop-in may be there instead of at
+# REDIS_DROPIN_TARGET. Check both locations.
+REDIS_DROPIN_SOURCE=""
+if [ -f "$REDIS_DROPIN_TARGET" ]; then
+  REDIS_DROPIN_SOURCE="$REDIS_DROPIN_TARGET"
+elif [ -f "$MEMCACHED_DROPIN_DISABLED" ]; then
+  REDIS_DROPIN_SOURCE="$MEMCACHED_DROPIN_DISABLED"
+fi
+
+if [ -n "$REDIS_DROPIN_SOURCE" ]; then
+  IS_REDIS_DROPIN=false
+  if [ -f "$REDIS_PLUGIN_DROPIN" ] && cmp -s "$REDIS_PLUGIN_DROPIN" "$REDIS_DROPIN_SOURCE"; then
+    IS_REDIS_DROPIN=true
+  elif grep -q "Plugin Name: Redis Object Cache Drop-In" "$REDIS_DROPIN_SOURCE" 2>/dev/null; then
+    IS_REDIS_DROPIN=true
+  fi
+  if [ "$IS_REDIS_DROPIN" = "true" ]; then
+    echo "Moving aside stale redis-cache object-cache.php drop-in..."
+    mv "$REDIS_DROPIN_SOURCE" "$REDIS_DROPIN_DISABLED_BACKEND" || true
+  else
+    echo "object-cache.php present but not recognized as the redis-cache drop-in; leaving it alone (likely user-managed)."
+  fi
+fi
+{{- end }}
+
 # ============================================================================
 # Memcached Plugin Safety
 # ============================================================================
-
 MEMCACHED_PLUGIN_DROPIN="/var/www/html/wp-content/plugins/memcached/object-cache.php"
 MEMCACHED_DROPIN_TARGET="/var/www/html/wp-content/object-cache.php"
 
+{{- if .Values.memcached.enabled }}
 if wp plugin is-active memcached 2>/dev/null; then
   echo "Deactivating memcached plugin (drop-in mode)..."
   wp plugin deactivate memcached 2>/dev/null || true
@@ -1577,6 +1620,30 @@ if php -m | grep -qi '^memcached$'; then
   fi
 else
   echo "Memcached extension missing in init; drop-in deferred to bootstrap."
+fi
+{{- else }}
+MEMCACHED_DROPIN_DISABLED_BACKEND="/var/www/html/wp-content/object-cache.php.helm-disabled-backend"
+
+if wp plugin is-active memcached 2>/dev/null; then
+  echo "Memcached backend disabled; deactivating memcached plugin..."
+  wp plugin deactivate memcached 2>/dev/null || true
+fi
+
+# The early wp-cli guard above unconditionally moves any existing object-cache.php
+# to $MEMCACHED_DROPIN_DISABLED before running - so the current drop-in may be
+# there instead of at MEMCACHED_DROPIN_TARGET. Check both locations.
+MEMCACHED_DROPIN_SOURCE=""
+if [ -f "$MEMCACHED_DROPIN_TARGET" ]; then
+  MEMCACHED_DROPIN_SOURCE="$MEMCACHED_DROPIN_TARGET"
+elif [ -f "$MEMCACHED_DROPIN_DISABLED" ]; then
+  MEMCACHED_DROPIN_SOURCE="$MEMCACHED_DROPIN_DISABLED"
+fi
+
+if [ -n "$MEMCACHED_DROPIN_SOURCE" ] && [ -f "$MEMCACHED_PLUGIN_DROPIN" ] && cmp -s "$MEMCACHED_PLUGIN_DROPIN" "$MEMCACHED_DROPIN_SOURCE"; then
+  echo "Moving aside stale memcached object-cache.php drop-in..."
+  mv "$MEMCACHED_DROPIN_SOURCE" "$MEMCACHED_DROPIN_DISABLED_BACKEND" || true
+elif [ -n "$MEMCACHED_DROPIN_SOURCE" ]; then
+  echo "object-cache.php present but memcached plugin source unavailable to verify signature; leaving it alone (likely user-managed)."
 fi
 {{- end }}
 

--- a/charts/wordpress/templates/_pod.tpl
+++ b/charts/wordpress/templates/_pod.tpl
@@ -505,9 +505,55 @@
               rm -f /etc/apt/apt.conf.d/99sandboxroot
               rm -rf /var/lib/apt/lists/*
           volumeMounts:
-            - name: wordpress-memcached-ext
+            - name: wordpress-php-ext
               mountPath: /opt/php-ext
             {{- include "wordpress.dataVolumeMounts" (dict "ctx" . "path" "/var/www/html") | nindent 12 }}
+        {{- end }}
+        {{- $cacheBackendsInit := (include "wordpress.cache.backends" . | fromYaml) }}
+        {{- if or (eq $cacheBackendsInit.selected "redis") (eq $cacheBackendsInit.selected "valkey") }}
+        - name: {{ .Chart.Name }}-redis-bootstrap
+          image: {{ include "slycharts.image" (dict "image" .Values.image "defaultTag" .Chart.AppVersion) }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
+          securityContext:
+            runAsUser: 0
+            runAsNonRoot: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - CHOWN
+                - DAC_OVERRIDE
+                - FOWNER
+                - SETGID
+                - SETUID
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: DEBUG
+              value: {{ .Values.wordpress.init.debug | default "false" | quote }}
+          command:
+            - sh
+            - -ec
+            - |
+              echo "Redis bootstrap: installation startet..."
+              if [ "${DEBUG:-false}" = "true" ]; then
+                pecl install redis
+              else
+                pecl install redis >/dev/null
+              fi
+              mkdir -p /opt/php-ext/conf.d /opt/php-ext/lib
+              EXT_DIR="$(php-config --extension-dir)"
+              cp "${EXT_DIR}/redis.so" /opt/php-ext/redis.so
+              ldd "${EXT_DIR}/redis.so" | awk '/=> \/.*/ {print $3} /^\/.*/ {print $1}' | sed 's/[[:space:]]*$//' | sort -u | while read -r lib; do
+                [ -f "$lib" ] && cp -L "$lib" /opt/php-ext/lib/
+              done
+              echo "extension=/opt/php-ext/redis.so" > /opt/php-ext/conf.d/zz-redis.ini
+              PHP_INI_SCAN_DIR="/usr/local/etc/php/conf.d:/opt/php-ext/conf.d" LD_LIBRARY_PATH="/opt/php-ext/lib" php -m | grep -qi '^redis$' || { echo "ERROR: redis extension failed to load"; exit 1; }
+              echo "Redis bootstrap: installation beendet."
+          volumeMounts:
+            - name: wordpress-php-ext
+              mountPath: /opt/php-ext
         {{- end }}
       {{- if .Values.initContainers }}
         {{- toYaml .Values.initContainers | nindent 8 }}
@@ -537,7 +583,7 @@
           {{- if or (eq $cacheBackends.selected "redis") (eq $cacheBackends.selected "valkey") }}
           {{- $cacheMeta = (include "wordpress.cache.kvMeta" (dict "ctx" . "backend" $cacheBackends.selected) | fromYaml) }}
           {{- end }}
-          {{- if .Values.memcached.enabled }}
+          {{- if or .Values.memcached.enabled (eq $cacheBackends.selected "redis") (eq $cacheBackends.selected "valkey") }}
             - name: PHP_INI_SCAN_DIR
               value: "/usr/local/etc/php/conf.d:/opt/php-ext/conf.d"
             - name: LD_LIBRARY_PATH
@@ -781,8 +827,8 @@
               mountPath: /tmp
             - name: run
               mountPath: /var/run
-            {{- if .Values.memcached.enabled }}
-            - name: wordpress-memcached-ext
+            {{- if or .Values.memcached.enabled (eq $cacheBackends.selected "redis") (eq $cacheBackends.selected "valkey") }}
+            - name: wordpress-php-ext
               mountPath: /opt/php-ext
             {{- end }}
             {{- if .Values.extraVolumeMounts }}
@@ -881,8 +927,9 @@
         emptyDir: {}
       - name: run
         emptyDir: {}
-      {{- if .Values.memcached.enabled }}
-      - name: wordpress-memcached-ext
+      {{- $cacheBackendsVol := (include "wordpress.cache.backends" . | fromYaml) }}
+      {{- if or .Values.memcached.enabled (eq $cacheBackendsVol.selected "redis") (eq $cacheBackendsVol.selected "valkey") }}
+      - name: wordpress-php-ext
         emptyDir: {}
       {{- end }}
       - name: {{ include "wordpress.fullname" . }}-configfiles


### PR DESCRIPTION
## Summary
- Add a `redis-bootstrap` init container that compiles the native redis PHP extension into a shared `wordpress-php-ext` emptyDir whenever the redis/valkey cache backend is selected (renamed from `wordpress-memcached-ext`, now shared by both backends).
- Clean up stale `redis-cache`/`memcached` `object-cache.php` drop-ins left behind on the PVC when a cache backend is switched off, so wp-cli bootstrap doesn't fatally break on the next release.
- Extend `verify.sh` with checks that the native redis extension is loaded and the `object-cache.php` drop-in is present when `valkey.enabled=true`.

## Test plan
- [x] `./charts/wordpress/samples/verify/verify.sh` — all checks passed (including new Step 15/16 redis extension + drop-in checks)
- [x] `./charts/wordpress/samples/verify/uninstall.sh` — cleanup verified
- [x] `helm lint` (pre-commit hook) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)