### PR TITLE
[wg-easy] Fix extraVolumes rendering

### DIFF
--- a/charts/wg-easy/templates/statefulset.yaml
+++ b/charts/wg-easy/templates/statefulset.yaml
@@ -216,7 +216,7 @@ spec:
         persistentVolumeClaim:
           claimName: {{ if .Values.storage.existingClaim }}{{ .Values.storage.existingClaim }}{{ else }}{{ include "wg-easy.fullname" . }}{{ end }}
       {{- if .Values.extraVolumes }}
-        {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- toYaml .Values.extraVolumes | nindent 6 }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/wg-easy/tests/statefulset_test.yaml
+++ b/charts/wg-easy/tests/statefulset_test.yaml
@@ -59,3 +59,18 @@ tests:
       - equal:
           path: spec.template.spec.securityContext.runAsUser
           value: 1000
+
+  - it: renders extra volumes at the pod volumes level
+    template: statefulset.yaml
+    set:
+      extraVolumes:
+        - name: custom-config
+          configMap:
+            name: custom-config
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: custom-config
+            configMap:
+              name: custom-config


### PR DESCRIPTION
# Summary

This fixes `extraVolumes` rendering in the `wg-easy` StatefulSet. The existing indentation nests additional volume entries beneath the persistent volume claim, causing Helm to emit invalid YAML whenever `extraVolumes` is non-empty.

The additional volumes are now rendered at the pod `volumes` list level, with a regression test covering a ConfigMap volume.

## Validation

- `helm lint charts/wg-easy`
- `helm template` with default values
- `helm template` with a non-empty `extraVolumes` value
- `helm unittest charts/wg-easy` — 6 tests passed
- kubeconform `-strict` for default and `extraVolumes` renders — 7/7 resources valid in each render

The cluster-mutating verify script was not run because the available Kubernetes context was a production cluster. The repository kind-based install workflow will perform the isolated server-side dry-run.

## Release metadata

The conventional `fix(wg-easy):` commit leaves the chart version, CHANGELOG, and ArtifactHub changes to the repository release-please workflow, as documented in `CLAUDE.md`. No documentation or sample changes are required for this rendering bug.