### PR TITLE
ci(renovate): add GITHUB_COM_TOKEN for cross-repo datasource lookups

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -43,3 +43,10 @@ jobs:
         env:
           RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
           LOG_LEVEL: "info"
+          # The App installation token above is scoped to this repo only, so it
+          # can't look up tags/releases on unrelated public repos (e.g. GitHub
+          # Actions referenced in workflows, like aquasecurity/trivy-action).
+          # A separate, read-only token raises the public API rate limit for
+          # those cross-repo datasource lookups. See:
+          # https://docs.renovatebot.com/self-hosted-configuration/#githubcomtoken
+          GITHUB_COM_TOKEN: ${{ secrets.RENOVATE_GITHUB_COM_TOKEN }}


### PR DESCRIPTION
## Summary
- Renovate's GitHub App installation token is scoped to `SlyBase/helm-charts` only, so it can't look up tags/releases on unrelated public repos referenced by GitHub Actions in workflows (e.g. `aquasecurity/trivy-action`), causing "Failed to look up ... no-result" warnings on the Dependency Dashboard.
- Adds `GITHUB_COM_TOKEN` (sourced from the new `RENOVATE_GITHUB_COM_TOKEN` secret, a scope-less classic PAT) to raise the public API rate limit for these cross-repo lookups, per Renovate's own self-hosted docs.

## Test plan
- [ ] Next `renovate.yml` run no longer reports the `aquasecurity/trivy-action` lookup warning on #568