### PR TITLE
fix(ci): temporarily prefer GITHUB_TOKEN over App token for OCI push

### DIFF
--- a/.github/workflows/oci-release.yaml
+++ b/.github/workflows/oci-release.yaml
@@ -193,12 +193,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ -n "$APP_TOKEN" ]; then
-            selected_token="$APP_TOKEN"
-            token_source="app"
-          else
+          # TEMPORARY: prefer GITHUB_TOKEN over the App token until the
+          # slybase-helm-charts-publisher App installation's package write
+          # access is fixed (ghcr.io currently rejects its pushes with
+          # "installation not allowed to Write organization package" even
+          # though the App declares packages:write). Revert to preferring
+          # APP_TOKEN once that's resolved.
+          if [ -n "$FALLBACK_TOKEN" ]; then
             selected_token="$FALLBACK_TOKEN"
             token_source="github"
+          else
+            selected_token="$APP_TOKEN"
+            token_source="app"
           fi
 
           echo "::add-mask::$selected_token"


### PR DESCRIPTION
## Summary
- ghcr.io rejects pushes from the `slybase-helm-charts-publisher` App installation token with `403: permission_denied: installation not allowed to Write organization package`, even though the App declares `packages:write`.
- Every release since wordpress 5.4.1 / wg-easy 1.1.1 has failed because of this.
- Temporarily prefer `GITHUB_TOKEN` (which worked reliably for months) over the App token in the OCI push step, until the App's package permissions are fixed on the org side.

## Test plan
- [ ] Merge and dispatch a release for wordpress 5.4.5 and wg-easy 1.1.1, confirm the push succeeds.
- [ ] Once App package access is fixed, revert priority back to the App token.