### PR TITLE
revert(ci): restore App token as primary for OCI push

### DIFF
--- a/.github/workflows/oci-release.yaml
+++ b/.github/workflows/oci-release.yaml
@@ -193,18 +193,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          # TEMPORARY: prefer GITHUB_TOKEN over the App token until the
-          # slybase-helm-charts-publisher App installation's package write
-          # access is fixed (ghcr.io currently rejects its pushes with
-          # "installation not allowed to Write organization package" even
-          # though the App declares packages:write). Revert to preferring
-          # APP_TOKEN once that's resolved.
-          if [ -n "$FALLBACK_TOKEN" ]; then
-            selected_token="$FALLBACK_TOKEN"
-            token_source="github"
-          else
+          if [ -n "$APP_TOKEN" ]; then
             selected_token="$APP_TOKEN"
             token_source="app"
+          else
+            selected_token="$FALLBACK_TOKEN"
+            token_source="github"
           fi
 
           echo "::add-mask::$selected_token"


### PR DESCRIPTION
## Summary
- Follow-up to #590. The App installation's package write access has now been fixed on the org side.
- Restores `APP_TOKEN` as the preferred credential for the OCI push step.

## Test plan
- [ ] Merge and dispatch a release to confirm the App token pushes successfully.