### PR TITLE
fix(ci): permanently prefer GITHUB_TOKEN for OCI push over App token

### DIFF
--- a/.github/workflows/oci-release.yaml
+++ b/.github/workflows/oci-release.yaml
@@ -193,12 +193,20 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ -n "$APP_TOKEN" ]; then
-            selected_token="$APP_TOKEN"
-            token_source="app"
-          else
+          # GitHub App installation tokens cannot write to organization-owned
+          # GHCR packages regardless of the App's declared permissions or the
+          # package's "Manage Actions access" settings — this is a platform
+          # limitation, not a config gap (see
+          # https://github.com/orgs/community/discussions/78090 and
+          # https://github.com/orgs/community/discussions/50180). Always use
+          # GITHUB_TOKEN for the OCI push; keep APP_TOKEN generation only for
+          # whatever else in this workflow may still need App identity.
+          if [ -n "$FALLBACK_TOKEN" ]; then
             selected_token="$FALLBACK_TOKEN"
             token_source="github"
+          else
+            selected_token="$APP_TOKEN"
+            token_source="app"
           fi
 
           echo "::add-mask::$selected_token"


### PR DESCRIPTION
## Summary
- Follow-up to #590 / #591. Retested with the App token preferred (#591): still fails with `403: permission_denied: installation not allowed to Write organization package`.
- Confirmed via GitHub Community discussions #78090 and #50180: GitHub App installation tokens cannot write to organization-owned GHCR packages — this is a platform limitation, not something fixable via App permissions or the package's "Manage Actions access" settings.
- Permanently prefer `GITHUB_TOKEN` for the OCI push step.

## Test plan
- [ ] Dispatch a release and confirm the push succeeds with GITHUB_TOKEN.